### PR TITLE
Fix/interface virtualbatches

### DIFF
--- a/synchronizer/synchronizer.go
+++ b/synchronizer/synchronizer.go
@@ -98,6 +98,7 @@ type Synchronizer interface {
 	SynchronizerL1InfoTreeQuerier
 	SynchronizerSequencedBatchesQuerier
 	SynchronizerReorgSupporter
+	SynchronizerVirtualBatchesQuerier
 }
 
 func NewSynchronizerFromConfigfile(ctx context.Context, configFile string) (Synchronizer, error) {

--- a/version.go
+++ b/version.go
@@ -13,7 +13,7 @@ import (
 // v0.2.7 - Initial sequence batches
 // v0.3.0 - Add block.Checked
 var (
-	Version = "v0.3.1"
+	Version = "v0.3.2"
 )
 
 // PrintVersion prints version info into the provided io.Writer.


### PR DESCRIPTION
Interface `SynchronizerVirtualBatchesQuerier` was not exposed

### What does this PR do?

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

### Reviewers

Main reviewers:

<!-- Main reviewers should do a full review. There should be 2 main reviewers, unless there is a good reason for not to do it -->

- @John
- @Doe

Codeowner reviewers:

<!-- Codeowners should review only the part of code that they own, they're added automatically as reviewers and it's good to let them know that they shouldn't do a full review -->

- @-Alice
- @-Bob
