### PR TITLE
Finalized configurable #63

### DIFF
--- a/synchronizer/config/config.go
+++ b/synchronizer/config/config.go
@@ -16,13 +16,13 @@ type Config struct {
 	// if it's zero it finds the etrog upgrade block
 	GenesisBlockNumber uint64 `mapstructure:"GenesisBlockNumber"`
 
-	// SyncBlockProtection specify the synchronization block (lastest, finalized, pending or safe) also can have an offset
+	// SyncBlockProtection specify the synchronization block (latest, finalized, pending or safe) also can have an offset
 	// example: safe/-10, then the safe block ten blocks before the safe block
-	SyncBlockProtection string `jsonschema:"enum=lastest,enum=safe, enum=pending, enum=finalized" mapstructure:"SyncBlockProtection"`
-	// SyncBlockFinalized specify what block is considered finalized (lastest, finalized, pending or safe) also can have an offset
+	SyncBlockProtection string `jsonschema:"enum=latest,enum=safe, enum=pending, enum=finalized" mapstructure:"SyncBlockProtection"`
+	// SyncBlockFinalized specify what block is considered finalized (latest, finalized, pending or safe) also can have an offset
 	// example: safe/-10, then the safe block ten blocks before the finalized block
 	// if not set assuming 'finalized'
-	SyncBlockFinalized string `jsonschema:"enum=lastest,enum=safe, enum=pending, enum=finalized" mapstructure:"SyncBlockFinalized"`
+	SyncBlockFinalized string `jsonschema:"enum=latest,enum=safe, enum=pending, enum=finalized" mapstructure:"SyncBlockFinalized"`
 
 	// OverrideStorageCheck is a flag to override the storage check
 	// take in account that without that check you can merge data from different rollups or differents L1 networks

--- a/synchronizer/config/config.go
+++ b/synchronizer/config/config.go
@@ -16,10 +16,13 @@ type Config struct {
 	// if it's zero it finds the etrog upgrade block
 	GenesisBlockNumber uint64 `mapstructure:"GenesisBlockNumber"`
 
-	// SyncBlockProtection specify the state to sync (lastest, finalized, pending or safe)
+	// SyncBlockProtection specify the synchronization block (lastest, finalized, pending or safe) also can have an offset
+	// example: safe/-10, then the safe block ten blocks before the safe block
 	SyncBlockProtection string `jsonschema:"enum=lastest,enum=safe, enum=pending, enum=finalized" mapstructure:"SyncBlockProtection"`
-	// Example: SyncBlockProtection= finalized, L1SafeBlockOffset= -10, then the safe block ten blocks before the finalized block
-	SyncBlockProtectionOffset int `mapstructure:"SyncBlockProtectionOffset"`
+	// SyncBlockFinalized specify what block is considered finalized (lastest, finalized, pending or safe) also can have an offset
+	// example: safe/-10, then the safe block ten blocks before the finalized block
+	// if not set assuming 'finalized'
+	SyncBlockFinalized string `jsonschema:"enum=lastest,enum=safe, enum=pending, enum=finalized" mapstructure:"SyncBlockFinalized"`
 
 	// OverrideStorageCheck is a flag to override the storage check
 	// take in account that without that check you can merge data from different rollups or differents L1 networks

--- a/synchronizer/internal/synchronizer_impl.go
+++ b/synchronizer/internal/synchronizer_impl.go
@@ -71,7 +71,7 @@ func NewSynchronizerImpl(
 		defer cancel()
 		return nil, fmt.Errorf("synchronizer.SyncBlockProtection have a wrong value. Err: %w", err)
 	}
-	finalizedBlockNumberFetcher := l1_check_block.NewSafeL1BlockNumberFetch(finalizedBlockPoint)
+	finalizedBlockNumberFetcher := l1_check_block.NewSafeL1BlockNumberFetch(finalizedBlockPoint).SetIfNotFoundReturnsZero()
 	syncPointBlockNumberFecther := l1_check_block.NewSafeL1BlockNumberFetch(syncBlockPoint)
 	reorgManager := l1sync.NewCheckReorgManager(ctx, ethMan, state)
 	blocksRetriever := l1sync.NewBlockPointsRetriever(

--- a/synchronizer/l1_check_block/safe_l1_block.go
+++ b/synchronizer/l1_check_block/safe_l1_block.go
@@ -4,13 +4,27 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"strings"
 
 	"github.com/0xPolygonHermez/zkevm-synchronizer-l1/log"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
+const (
+	L1BlockPointWithOffsetDelimiter = "/"
+)
+
 // L1BlockPoint is an enum that represents the point of the L1 block
 type L1BlockPoint int
+
+type L1BlockPointWithOffset struct {
+	BlockPoint L1BlockPoint
+	Offset     int
+}
+
+func (v L1BlockPointWithOffset) String() string {
+	return fmt.Sprintf("%s%s%d", v.BlockPoint.ToString(), L1BlockPointWithOffsetDelimiter, v.Offset)
+}
 
 const (
 	// FinalizedBlockNumber is the finalized block number
@@ -39,18 +53,42 @@ func (v L1BlockPoint) ToString() string {
 }
 
 // StringToL1BlockPoint converts a string to a L1BlockPoint
-func StringToL1BlockPoint(s string) L1BlockPoint {
+func StringToL1BlockPointWithOffset(s string) (L1BlockPointWithOffset, error) {
+	result := L1BlockPointWithOffset{}
+	splitted := strings.Split(s, L1BlockPointWithOffsetDelimiter)
+	if len(splitted) > 2 {
+		return result, fmt.Errorf("invalid L1BlockPointWithOffset string: %s (only 1 delimiter permitted)", s)
+	}
+	l1block, err := StringToL1BlockPoint(splitted[0])
+	if err != nil {
+		return result, err
+	}
+	result.BlockPoint = l1block
+	if len(splitted) == 2 {
+		offset, err := fmt.Sscanf(splitted[1], "%d", &result.Offset)
+		if err != nil {
+			return result, fmt.Errorf("invalid L1BlockPointWithOffset string: %s (offset must be an integer)", s)
+		}
+		if offset != 1 {
+			return result, fmt.Errorf("invalid L1BlockPointWithOffset string: %s (only 1 offset permitted)", s)
+		}
+	}
+	return result, nil
+}
+
+// StringToL1BlockPoint converts a string to a L1BlockPoint
+func StringToL1BlockPoint(s string) (L1BlockPoint, error) {
 	switch s {
 	case "finalized":
-		return FinalizedBlockNumber
+		return FinalizedBlockNumber, nil
 	case "safe":
-		return SafeBlockNumber
+		return SafeBlockNumber, nil
 	case "pending":
-		return PendingBlockNumber
+		return PendingBlockNumber, nil
 	case "latest":
-		return LastBlockNumber
+		return LastBlockNumber, nil
 	default:
-		return FinalizedBlockNumber
+		return FinalizedBlockNumber, fmt.Errorf("invalid L1BlockPoint string: %s", s)
 	}
 }
 
@@ -69,52 +107,48 @@ func (v L1BlockPoint) ToGethRequest() *big.Int {
 	return big.NewInt(int64(v))
 }
 
-// SafeL1BlockNumberFetch is a struct that implements a safe L1 block number fetch
-type SafeL1BlockNumberFetch struct {
-	// SafeBlockPoint is the block number that is reference to l1 Block
-	SafeBlockPoint L1BlockPoint
-	// Offset is a vaule add to the L1 block
-	Offset int
-}
+// SafeL1BlockNumberFetch  implements a safe L1 block number fetch
+type SafeL1BlockNumberFetch = L1BlockPointWithOffset
 
 // NewSafeL1BlockNumberFetch creates a new SafeL1BlockNumberFetch
-func NewSafeL1BlockNumberFetch(safeBlockPoint L1BlockPoint, offset int) *SafeL1BlockNumberFetch {
-	return &SafeL1BlockNumberFetch{
-		SafeBlockPoint: safeBlockPoint,
-		Offset:         offset,
-	}
+func NewSafeL1BlockNumberFetch(safeBlockPointWithOffset L1BlockPointWithOffset) *SafeL1BlockNumberFetch {
+	res := SafeL1BlockNumberFetch(safeBlockPointWithOffset)
+	return &res
 }
 
 // Description returns a string representation of SafeL1BlockNumberFetch
 func (p *SafeL1BlockNumberFetch) Description() string {
-	return fmt.Sprintf("%s/%d", p.SafeBlockPoint.ToString(), p.Offset)
+	if p == nil {
+		return "nil"
+	}
+	return (*p).String()
 }
 
 // GetSafeBlockNumber gets the safe block number from L1
 func (p *SafeL1BlockNumberFetch) GetSafeBlockNumber(ctx context.Context, requester L1Requester) (uint64, error) {
-	l1SafePointBlock, err := requester.HeaderByNumber(ctx, p.SafeBlockPoint.ToGethRequest())
+	l1SafePointBlock, err := requester.HeaderByNumber(ctx, p.BlockPoint.ToGethRequest())
+	blockNumber := uint64(0)
 	if err != nil {
-		log.Errorf("%s: Error getting L1 block %d. err: %s", logPrefix, p.String(), err.Error())
-		return uint64(0), err
-	}
-	result := l1SafePointBlock.Number.Uint64()
-	if p.Offset < 0 {
-		if result < uint64(-p.Offset) {
-			result = 0
+		if strings.Contains(err.Error(), "block not found") {
+			log.Warnf("block %s not found, assuming 0", p.String())
 		} else {
-			result += uint64(p.Offset)
+			log.Errorf("%s: Error getting L1 block %d. err: %s", logPrefix, p.String(), err.Error())
+			return uint64(0), err
+		}
+	}
+	blockNumber = l1SafePointBlock.Number.Uint64()
+	if p.Offset < 0 {
+		if blockNumber < uint64(-p.Offset) {
+			blockNumber = 0
+		} else {
+			blockNumber += uint64(p.Offset)
 		}
 	} else {
-		result = l1SafePointBlock.Number.Uint64() + uint64(p.Offset)
+		blockNumber = l1SafePointBlock.Number.Uint64() + uint64(p.Offset)
 	}
-	if p.SafeBlockPoint == LastBlockNumber {
-		result = min(result, l1SafePointBlock.Number.Uint64())
+	if p.BlockPoint == LastBlockNumber {
+		blockNumber = min(blockNumber, l1SafePointBlock.Number.Uint64())
 	}
 
-	return result, nil
-}
-
-// String returns a string representation of SafeL1BlockNumberFetch
-func (p *SafeL1BlockNumberFetch) String() string {
-	return fmt.Sprintf("SafeBlockPoint: %s, Offset: %d", p.SafeBlockPoint.ToString(), p.Offset)
+	return blockNumber, nil
 }

--- a/synchronizer/l1_check_block/safe_l1_block_test.go
+++ b/synchronizer/l1_check_block/safe_l1_block_test.go
@@ -2,6 +2,7 @@ package l1_check_block_test
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -18,7 +19,11 @@ func TestGetSafeBlockNumber(t *testing.T) {
 	mockRequester := mock_l1_check_block.NewL1Requester(t)
 	//safeBlockPoint := big.NewInt(50)
 	offset := 10
-	safeL1Block := l1_check_block.NewSafeL1BlockNumberFetch(l1_check_block.StringToL1BlockPoint("safe"), offset)
+	syncPoint := l1_check_block.L1BlockPointWithOffset{
+		BlockPoint: l1_check_block.SafeBlockNumber,
+		Offset:     offset,
+	}
+	safeL1Block := l1_check_block.NewSafeL1BlockNumberFetch(syncPoint)
 
 	mockRequester.EXPECT().HeaderByNumber(ctx, mock.Anything).Return(&types.Header{
 		Number: big.NewInt(100),
@@ -100,7 +105,10 @@ func TestGetSafeBlockNumberMutliplesCases(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 			mockRequester := mock_l1_check_block.NewL1Requester(t)
-			safeL1Block := l1_check_block.NewSafeL1BlockNumberFetch(l1_check_block.StringToL1BlockPoint(tt.blockPoint), tt.offset)
+			syncPointStr := fmt.Sprintf("%s/%d", tt.blockPoint, tt.offset)
+			syncPoint, err := l1_check_block.StringToL1BlockPointWithOffset(syncPointStr)
+			assert.NoError(t, err)
+			safeL1Block := l1_check_block.NewSafeL1BlockNumberFetch(syncPoint)
 
 			mockRequester.EXPECT().HeaderByNumber(ctx, tt.expectedCallToGeth).Return(&types.Header{
 				Number: big.NewInt(int64(tt.l1ReturnBlockNumber)),
@@ -108,6 +116,55 @@ func TestGetSafeBlockNumberMutliplesCases(t *testing.T) {
 			blockNumber, err := safeL1Block.GetSafeBlockNumber(ctx, mockRequester)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedBlockNumber, blockNumber)
+		})
+	}
+}
+
+func TestGetSafeBlockNumberWithOffsetMutliplesCases(t *testing.T) {
+	tests := []struct {
+		name       string
+		blockPoint string
+		expected   l1_check_block.L1BlockPointWithOffset
+		err        bool
+	}{
+		{
+			name:       "SafeBlockNumber+10",
+			blockPoint: "safe/10",
+			expected:   l1_check_block.L1BlockPointWithOffset{BlockPoint: l1_check_block.SafeBlockNumber, Offset: 10},
+		},
+		{
+			name:       "SafeBlockNumber+10",
+			blockPoint: "safe/-10",
+			expected:   l1_check_block.L1BlockPointWithOffset{BlockPoint: l1_check_block.SafeBlockNumber, Offset: -10},
+		},
+		{
+			name:       "SafeBlockNumber+10",
+			blockPoint: "safe",
+			expected:   l1_check_block.L1BlockPointWithOffset{BlockPoint: l1_check_block.SafeBlockNumber, Offset: 0},
+		},
+		{
+			name:       "bad1",
+			blockPoint: "safe/10/20",
+			expected:   l1_check_block.L1BlockPointWithOffset{BlockPoint: l1_check_block.SafeBlockNumber, Offset: 0},
+			err:        true,
+		},
+		{
+			name:       "bad2",
+			blockPoint: "unknown_value/10",
+			expected:   l1_check_block.L1BlockPointWithOffset{BlockPoint: l1_check_block.SafeBlockNumber, Offset: 0},
+			err:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := l1_check_block.StringToL1BlockPointWithOffset(tt.blockPoint)
+			if tt.err {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
 		})
 	}
 }

--- a/synchronizer/l1_check_block/safe_l1_block_test.go
+++ b/synchronizer/l1_check_block/safe_l1_block_test.go
@@ -168,3 +168,25 @@ func TestGetSafeBlockNumberWithOffsetMutliplesCases(t *testing.T) {
 		})
 	}
 }
+
+func TestGetSafeBlockNumberNotFound(t *testing.T) {
+	ctx := context.Background()
+	mockRequester := mock_l1_check_block.NewL1Requester(t)
+	//safeBlockPoint := big.NewInt(50)
+	offset := 10
+	syncPoint := l1_check_block.L1BlockPointWithOffset{
+		BlockPoint: l1_check_block.SafeBlockNumber,
+		Offset:     offset,
+	}
+	mockRequester.EXPECT().HeaderByNumber(ctx, mock.Anything).Return(nil, fmt.Errorf("block not found"))
+	safeL1Block := l1_check_block.NewSafeL1BlockNumberFetch(syncPoint)
+	_, err := safeL1Block.GetSafeBlockNumber(ctx, mockRequester)
+	assert.Error(t, err)
+
+	mockRequester.EXPECT().HeaderByNumber(ctx, mock.Anything).Return(nil, fmt.Errorf("block not found"))
+	safeL1Block = l1_check_block.NewSafeL1BlockNumberFetch(syncPoint).SetIfNotFoundReturnsZero()
+	block, err := safeL1Block.GetSafeBlockNumber(ctx, mockRequester)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(0), block)
+
+}

--- a/version.go
+++ b/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	Version = "v0.4.2"
+	Version = "v0.5.0"
 )
 
 // PrintVersion prints version info into the provided io.Writer.


### PR DESCRIPTION
Closes #63

### What does this PR do?
- Assume that if finalized  block is  `not found` on L1 is a 0

## Configuration changes
- Removed field `SyncBlockProtectionOffset`: now you can setup this in `SyncBlockProtection` as `safe/-10`
- Add `SyncBlockFinalized` as what is considered finalized by syncer (also admin `/<offset>`)

Main reviewers:

- @ToniRamirezM 
- @ARR552 

