### PR TITLE
fix case of no blocks on L1

### DIFF
--- a/synchronizer/internal/synchronizer_impl.go
+++ b/synchronizer/internal/synchronizer_impl.go
@@ -248,7 +248,7 @@ func (s *SynchronizerImpl) Sync(executionFlags SyncExecutionFlags) error {
 			}
 			s.setSyncedStatus(isSynced)
 			if s.synced {
-				log.Infof("NetworkID %d Synced!   lastBlockSynced:%d ", s.networkID, lastBlockSynced.BlockNumber)
+				log.Infof("NetworkID %d Synced!   lastBlockSynced:%s", s.networkID, lastBlockSynced.String())
 				if (executionFlags & FlagReturnOnSync) != 0 {
 					log.Infof("NetworkID: %d, Synchronization finished, returning because returnOnSync=true", s.networkID)
 					return nil

--- a/synchronizer/internal/synchronizer_impl_test.go
+++ b/synchronizer/internal/synchronizer_impl_test.go
@@ -16,6 +16,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestSyncImplNoL1BlockYet(t *testing.T) {
+	testData := newTestDataSyncImpl(t)
+	testData.mockStorage.EXPECT().GetLastBlock(mock.Anything, mock.Anything).Return(nil, entities.ErrNotFound)
+	// It returns block=nil but is synced and no error
+	testData.mockL1Syncer.EXPECT().SyncBlocks(testData.ctx, mock.Anything).Return(nil, true, nil)
+	err := testData.sut.Sync(FlagReturnBeforeReorg | FlagReturnOnSync)
+	require.NoError(t, err)
+}
+
 // TestFirstExecutionIsSynced
 // This test is that receive 1 block and is synced
 // is called to return on sync to it returns with no error

--- a/version.go
+++ b/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	Version = "v0.6.2"
+	Version = "v0.6.3"
 )
 
 // PrintVersion prints version info into the provided io.Writer.


### PR DESCRIPTION

### What does this PR do?
If there are no block on L1 yet, then the sync return as synced but no "lastblock" this procude a panic because try to print the blockNumber of a nil pointer

### Reviewers
