### PR TITLE
fix:Avoid requests empty block range

### DIFF
--- a/synchronizer/l1_sync/block_range_iterator.go
+++ b/synchronizer/l1_sync/block_range_iterator.go
@@ -53,7 +53,7 @@ func (i *BlockRangeIterator) NextRange(fromBlock uint64) *BlockRangeIterator {
 	if i.toBlock > i.MaximumBlock {
 		i.toBlock = i.MaximumBlock
 	}
-	if i.fromBlock > i.toBlock {
+	if i.fromBlock >= i.toBlock {
 		return nil
 	}
 	return i

--- a/synchronizer/l1_sync/bock_range_iterator_test.go
+++ b/synchronizer/l1_sync/bock_range_iterator_test.go
@@ -79,3 +79,11 @@ func TestBlockRange_SettingWrongFromBlockReturnsNil(t *testing.T) {
 	it := l1sync.NewBlockRangeIterator(fromBlock, chunck, lastBlock)
 	require.Nil(t, it)
 }
+
+func TestBlockRange_IsAlreadySincornizedReturnsNilblockRangeIterator(t *testing.T) {
+	chunck := uint64(10)
+	fromBlock := uint64(110)
+	maxBlock := uint64(110)
+	blockRangeIterator := l1sync.NewBlockRangeIterator(fromBlock, chunck, maxBlock)
+	require.Nil(t, blockRangeIterator)
+}

--- a/synchronizer/l1_sync/l1_syncer_sequential_test.go
+++ b/synchronizer/l1_sync/l1_syncer_sequential_test.go
@@ -70,10 +70,10 @@ func TestSyncBlocksSequentialNothingToDo(t *testing.T) {
 func TestSyncBlocksSequentialReorgMissingFirstBlockOnRollupResponse(t *testing.T) {
 	testData := newL1SyncData(t)
 	testData.mockBlockRetriever.EXPECT().GetL1BlockPoints(testData.ctx).Return(l1sync.BlockPoints{
-		L1LastBlockToSync:      100,
+		L1LastBlockToSync:      101,
 		L1FinalizedBlockNumber: 100,
 	}, nil)
-	toBlock := uint64(100)
+	toBlock := uint64(101)
 	testData.mockEth.EXPECT().GetRollupInfoByBlockRange(testData.ctx, uint64(100), &toBlock).Return(nil, nil, nil)
 	_, _, err := testData.sut.SyncBlocks(testData.ctx, testData.lastEthBlock)
 	require.Error(t, err)
@@ -82,10 +82,10 @@ func TestSyncBlocksSequentialReorgMissingFirstBlockOnRollupResponse(t *testing.T
 func TestSyncBlocksSequentialReorgDetected(t *testing.T) {
 	testData := newL1SyncData(t)
 	testData.mockBlockRetriever.EXPECT().GetL1BlockPoints(testData.ctx).Return(l1sync.BlockPoints{
-		L1LastBlockToSync:      100,
+		L1LastBlockToSync:      101,
 		L1FinalizedBlockNumber: 100,
 	}, nil)
-	toBlock := uint64(100)
+	toBlock := uint64(101)
 	testData.mockEth.EXPECT().GetRollupInfoByBlockRange(testData.ctx, uint64(100), &toBlock).Return(nil, nil, nil)
 	_, _, err := testData.sut.SyncBlocks(testData.ctx, testData.lastEthBlock)
 	require.Error(t, err)

--- a/version.go
+++ b/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	Version = "v0.7.0"
+	Version = "v0.7.1"
 )
 
 // PrintVersion prints version info into the provided io.Writer.


### PR DESCRIPTION
Closes #<issue number>.

### What does this PR do?

When the synchronizer is on top block,  synchronized must stop asking for data

