### PR TITLE
fix: Panic if receive a UpdateL1InfoTreeV2 without previous UpdateL1InfoTree

### DIFF
--- a/synchronizer/actions/banana/processor_update_l1_info_tree_v2.go
+++ b/synchronizer/actions/banana/processor_update_l1_info_tree_v2.go
@@ -47,10 +47,15 @@ func (p *ProcessorUpdateL1InfoTreeV2) ProcessUpdateL1InfoTreeV2(ctx context.Cont
 		log.Errorf("error getting the state leaf. Error: %v", err)
 		return err
 	}
-	err = compareL1InfoTreeLeaf(*stateLeaf, data)
-	if err != nil {
-		log.Errorf("error comparing the state leaf. Error: %v", err)
-		return err
+	if stateLeaf != nil {
+		err = compareL1InfoTreeLeaf(*stateLeaf, data)
+		if err != nil {
+			log.Errorf("error comparing the state leaf. Error: %v", err)
+			return err
+		}
+		log.Infof("L1InfoTreeLeafV2 sanity check OK: %s", data.String())
+	} else {
+		log.Warnf("this l1nfotree is not stored on local DB. So can't check it: data:%s ", data.String())
 	}
 	return nil
 }

--- a/version.go
+++ b/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	Version = "v1.0.2"
+	Version = "v1.0.3"
 )
 
 // PrintVersion prints version info into the provided io.Writer.


### PR DESCRIPTION
Closes #122
